### PR TITLE
Use curl instead of wget on macOS and fix Linux install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,32 @@ This new Wasm file can be used just like any other Extism plugin.
 
 We now have released binaries. Check the [releases](https://github.com/extism/js-pdk/releases) page for the latest.
 
-> **Note**: I can't give windows instructions yet but this should work for mac and linux:
+> **Note**: Windows is not currently a supported platform.
+
+### Installing on a Mac
+
+Run the script below to install on Mac:
 
 ```bash
 export TAG=v0.2.0
-wget "https://github.com/extism/js-pdk/releases/download/$TAG/extism-js-x86_64-macos-$TAG.gz"
+curl -O "https://github.com/extism/js-pdk/releases/download/$TAG/extism-js-x86_64-macos-$TAG.gz"
 gunzip extism-js*.gz
 sudo mv extism-js-* /usr/local/bin/extism-js
 chmod +x /usr/local/bin/extism-js
 ```
+
+### Installing on Linux
+
+Run the script below to install on Linux:
+
+```bash
+export TAG=v0.2.0
+curl -O "https://github.com/extism/js-pdk/releases/download/$TAG/extism-js-x86_64-linux-$TAG.gz"
+gunzip extism-js*.gz
+sudo mv extism-js-* /usr/local/bin/extism-js
+chmod +x /usr/local/bin/extism-js
+```
+
 
 Then run command with no args to see the help:
 


### PR DESCRIPTION
wget isn't installed by default on macOS.  Update the script to use curl instead.
