### PR TITLE
Update readme to provide more context on compilation from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,21 +172,27 @@ faster World
 
 ## Compiling the compiler from source
 
-You need the wasi sdk which can be fetched with the makefile:
+### Prerequisites
+Before compiling the compiler, you need to install prerequisites.
 
-```
-make download-wasi-sdk
-```
+1. Install Rust using [rustup](https://rustup.rs)
+2. Install the WASI target platform via `rustup target add --toolchain stable wasm32-wasi`
+3. Install the wasi sdk using the makefile command: `make download-wasi-sdk`
+4. Install [CMake](https://cmake.org/install/) (on macOS with homebrew, `brew install cmake`)
 
-Then run make to compile the core crate (the engine) and the cli:
+
+### Compiling from source
+
+Run make to compile the core crate (the engine) and the cli:
 
 ```
 make
 ```
 
+To test the built compiler (ensure you have Extism installed):
 ```bash
-./target/release/extism-js script.js -o out.wasm
-extism call out.wasm count_vowels --wasi --input="Hello World Test!"
+./target/release/extism-js bundle.js -o out.wasm
+extism call out.wasm count_vowels --wasi --input='Hello World Test!'
 # => "{\"count\":4}"
 ```
 


### PR DESCRIPTION
* Provide some prerequisite info on how to set up the toolchain for building the SDK
* Fix quotes in `"Hello World Test!"` which was causing an issue in zsh in MacOS related to the `!` being treated as a special character.
* Switch the script that's passed to the build example to use the `bundle.js` instead of `script.js`, which isn't buildable since it's not in cjs format.

Issue caused by the `!` (unterminated quote denoted by the `dquote>` prompt)
```
➜  js-pdk git:(main) ✗ extism call out.wasm count_vowels --wasi --input="Hello World Test!"
dquote> 
➜  js-pdk git:(main) ✗ extism call out.wasm count_vowels --wasi --input='Hello World Test!'
{"count":4}% ```