### PR TITLE
fix: Fixes HTTP Call code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0-rc1"
+version = "1.0.0-rc2"
 edition = "2021"
 authors = ["The Extism Authors"]
 license = "BSD-Clause-3"

--- a/crates/core/src/globals.rs
+++ b/crates/core/src/globals.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, collections::HashMap, str::from_utf8};
 
-use anyhow::{anyhow, bail};
+use anyhow::{anyhow, bail, Context};
 use extism_pdk::extism::load_input;
 use extism_pdk::*;
 use quickjs_wasm_rs::{JSContextRef, JSError, JSValue, JSValueRef};
@@ -174,28 +174,21 @@ fn build_http_object(context: &JSContextRef) -> anyhow::Result<JSValueRef> {
 
             let url = req
                 .get_property("url")
-                .expect("Http Request should have url property");
+                .context("Http Request should have url property")?;
 
-            extism_pdk::info!("property method");
             let method = req.get_property("method");
-            extism_pdk::info!("property method got");
             let method_str = match method {
                 Ok(m) => m.as_str()?.to_string(),
                 Err(..) => "GET".to_string(),
             };
-            extism_pdk::info!("{}", method_str);
 
             let mut http_req = HttpRequest::new(url.as_str()?).with_method(method_str);
-            extism_pdk::info!("request built");
 
             let headers = req.get_property("headers")?;
-            extism_pdk::info!("got headers");
             if !headers.is_null_or_undefined() {
-                extism_pdk::info!("headers present");
                 if !headers.is_object() {
                     bail!("Expected headers to be an object");
                 }
-                extism_pdk::info!("is an object");
                 if !headers.is_object() {
                     let mut header_values = headers.properties()?;
                     loop {
@@ -212,21 +205,14 @@ fn build_http_object(context: &JSContextRef) -> anyhow::Result<JSValueRef> {
                     }
                 }
             }
-            extism_pdk::info!("headers done");
 
-            let body_arg = args.get(1).ok_or(ctx.null_value()?).unwrap();
-            extism_pdk::info!("body args");
+            let body_arg = args.get(1);
             let mut http_body: Option<String> = None;
-            if !body_arg.is_null_or_undefined() {
-                let body_arg = body_arg.as_str()?;
-                http_body = Some(body_arg.to_string());
+            if let Some(body) = body_arg {
+                http_body = Some(body.as_str()?.to_string());
             }
-            extism_pdk::info!("http body set");
 
-            extism_pdk::info!("ok");
             let resp = http::request::<String>(&http_req, http_body)?;
-            extism_pdk::info!("");
-
             let body = resp.body();
             let body = from_utf8(&body)?;
 

--- a/examples/simple_js/script.js
+++ b/examples/simple_js/script.js
@@ -6,12 +6,9 @@
 function callHttp() {
   const request = {
     method: "GET",
-    url: "https://jsonplaceholder.typicode.com/todos/1",
-    headers: {
-      "Accept": "application/json"
-    }
+    url: "https://jsonplaceholder.typicode.com/todos/1"
   }
-  const response = Http.request(request, "")
+  const response = Http.request(request)
   if (response.status != 200) throw new Error(`Got non 200 response ${response.status}`)
   Host.outputString(response.body)
 }

--- a/examples/simple_js/script.js
+++ b/examples/simple_js/script.js
@@ -2,8 +2,18 @@
  * A simple example of a JavaScript, CJS flavored plug-in:
  */
 
-function greet() {
-  Host.outputString(`Hello, ${Host.inputString()}`)
+
+function callHttp() {
+  const request = {
+    method: "GET",
+    url: "https://jsonplaceholder.typicode.com/todos/1",
+    headers: {
+      "Accept": "application/json"
+    }
+  }
+  const response = Http.request(request, "")
+  if (response.status != 200) throw new Error(`Got non 200 response ${response.status}`)
+  Host.outputString(response.body)
 }
 
-module.exports = { greet }
+module.exports = { callHttp }

--- a/examples/simple_js/script.js
+++ b/examples/simple_js/script.js
@@ -2,15 +2,8 @@
  * A simple example of a JavaScript, CJS flavored plug-in:
  */
 
-
-function callHttp() {
-  const request = {
-    method: "GET",
-    url: "https://jsonplaceholder.typicode.com/todos/1"
-  }
-  const response = Http.request(request)
-  if (response.status != 200) throw new Error(`Got non 200 response ${response.status}`)
-  Host.outputString(response.body)
+function greet() {
+  Host.outputString(`Hello, ${Host.inputString()}`)
 }
 
-module.exports = { callHttp }
+module.exports = { greet }

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ case "$ARCH" in
 esac
 
 
-export TAG="v1.0.0-rc1"
+export TAG="v1.0.0-rc2"
 curl -L -O "https://github.com/extism/js-pdk/releases/download/$TAG/extism-js-$ARCH-$OS-$TAG.gz"
 gunzip extism-js*.gz
 sudo mv extism-js-* /usr/local/bin/extism-js


### PR DESCRIPTION
Fixes #36 

Had some misunderstandings of the quickjs interface in rust in this code. This fixes the problem. However I think a longer term fix would be to move more of this code up into the polyfill / prelude area: https://github.com/extism/js-pdk/tree/main/crates/core/src/prelude

The reason being that more of our validation and preparation logic should be written in JS rather than rust because it's more ergonomic and the error messages are better.