### PR TITLE
fix: use uname for os detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,9 @@
 set -e
 
 OS=''
-case "$OSTYPE" in
-  darwin*)  OS="macos" ;; 
-  linux*)   OS="linux" ;;
+case `uname` in
+  Darwin*)  OS="macos" ;; 
+  Linux*)   OS="linux" ;;
   *)        echo "unknown os: $OSTYPE" && exit 1 ;;
 esac
 


### PR DESCRIPTION
`$OSTYPE` didn't work on my linux, so I just figured since already use `uname` in the script, we can double-dip. 