### PR TITLE
add download and install of binaryen bin files to install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,19 +18,27 @@ esac
 export TAG="v1.0.0-rc4"
 export BINARYEN_TAG="version_116"
 
-
 curl -L -O "https://github.com/extism/js-pdk/releases/download/$TAG/extism-js-$ARCH-$OS-$TAG.gz"
-curl -L -O "https://github.com/WebAssembly/binaryen/releases/download/$BINARYEN_TAG/binaryen-$BINARYEN_TAG-$ARCH-$OS.tar.gz"
 
 gunzip extism-js*.gz
 sudo mv extism-js-* /usr/local/bin/extism-js
 chmod +x /usr/local/bin/extism-js
 
-tar xvf "binaryen-$BINARYEN_TAG-$ARCH-$OS.tar.gz"
-mv "binaryen-$BINARYEN_TAG"/ binaryen/
-sudo mkdir /usr/local/binaryen
-sudo mv binaryen/bin/wasm* /usr/local/binaryen
+if ! which "wasm-merge" > /dev/null; then
+  echo "Installing wasm-merge..."
 
-for file in $(ls /usr/local/binaryen); do
-  sudo ln -s  /usr/local/binaryen/$file /usr/local/bin/$file
-done
+  # binaryen use arm64 instead where as extism-js uses aarch64 for release file naming
+  case "$ARCH" in
+    aarch64*)  ARCH="arm64" ;;
+  esac
+
+  curl -L -O "https://github.com/WebAssembly/binaryen/releases/download/$BINARYEN_TAG/binaryen-$BINARYEN_TAG-$ARCH-$OS.tar.gz"
+  tar xf "binaryen-$BINARYEN_TAG-$ARCH-$OS.tar.gz"
+  mv "binaryen-$BINARYEN_TAG"/ binaryen/
+  sudo mkdir /usr/local/binaryen
+  sudo mv binaryen/bin/wasm-merge /usr/local/binaryen/wasm-merge
+  sudo ln -s /usr/local/binaryen/wasm-merge /usr/local/bin/wasm-merge
+
+else
+  echo "wasm-merge already installed"
+fi

--- a/install.sh
+++ b/install.sh
@@ -2,21 +2,35 @@ set -e
 
 OS=''
 case `uname` in
-  Darwin*)  OS="macos" ;; 
+  Darwin*)  OS="macos" ;;
   Linux*)   OS="linux" ;;
   *)        echo "unknown os: $OSTYPE" && exit 1 ;;
 esac
 
 ARCH=`uname -m`
 case "$ARCH" in
-  ix86*|x86_64*)    ARCH="x86_64" ;; 
+  ix86*|x86_64*)    ARCH="x86_64" ;;
   arm64*|aarch64*)  ARCH="aarch64" ;;
   *)                echo "unknown arch: $ARCH" && exit 1 ;;
 esac
 
 
 export TAG="v1.0.0-rc4"
+export BINARYEN_TAG="version_116"
+
+
 curl -L -O "https://github.com/extism/js-pdk/releases/download/$TAG/extism-js-$ARCH-$OS-$TAG.gz"
+curl -L -O "https://github.com/WebAssembly/binaryen/releases/download/$BINARYEN_TAG/binaryen-$BINARYEN_TAG-$ARCH-$OS.tar.gz"
+
 gunzip extism-js*.gz
 sudo mv extism-js-* /usr/local/bin/extism-js
 chmod +x /usr/local/bin/extism-js
+
+tar xvf "binaryen-$BINARYEN_TAG-$ARCH-$OS.tar.gz"
+mv "binaryen-$BINARYEN_TAG"/ binaryen/
+sudo mkdir /usr/local/binaryen
+sudo mv binaryen/bin/wasm* /usr/local/binaryen
+
+for file in $(ls /usr/local/binaryen); do
+  sudo ln -s  /usr/local/binaryen/$file /usr/local/bin/$file
+done


### PR DESCRIPTION
I had an issue with building a plugin because `binaryen` wasn't installed/in my path. I mentioned on discord that having the install include `binaryen` be a good idea.

Looking for feedback on this.

Didn't find a contribution guide, apologies if I have missed steps in the process.