### PR TITLE
Unable to run wasm-merge with a Linux and docker based Docker image running on a Mac m1

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,8 +37,6 @@ if ! which "wasm-merge" > /dev/null; then
     ARCH="x86_64"
   fi
 
-  echo "https://github.com/WebAssembly/binaryen/releases/download/$BINARYEN_TAG/binaryen-$BINARYEN_TAG-$ARCH-$OS.tar.gz"
-
   curl -L -O "https://github.com/WebAssembly/binaryen/releases/download/$BINARYEN_TAG/binaryen-$BINARYEN_TAG-$ARCH-$OS.tar.gz"
   tar xf "binaryen-$BINARYEN_TAG-$ARCH-$OS.tar.gz"
   mv "binaryen-$BINARYEN_TAG"/ binaryen/

--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,14 @@ if ! which "wasm-merge" > /dev/null; then
     aarch64*)  ARCH="arm64" ;;
   esac
 
+  # matches the case where the user installs extism-pdk in a Linux-based Docker image running on mac m1
+  # binaryen didn't have arm64 release file for linux 
+  if [ $ARCH = "arm64" ] && [ $OS = "linux" ]; then
+    ARCH="x86_64"
+  fi
+
+  echo "https://github.com/WebAssembly/binaryen/releases/download/$BINARYEN_TAG/binaryen-$BINARYEN_TAG-$ARCH-$OS.tar.gz"
+
   curl -L -O "https://github.com/WebAssembly/binaryen/releases/download/$BINARYEN_TAG/binaryen-$BINARYEN_TAG-$ARCH-$OS.tar.gz"
   tar xf "binaryen-$BINARYEN_TAG-$ARCH-$OS.tar.gz"
   mv "binaryen-$BINARYEN_TAG"/ binaryen/


### PR DESCRIPTION
I'm trying to install and run the `js-pdk` in a Docker image based on `ubuntu:22.04`. My docker runs on a mac m1. 

When I run the install.sh script it always failed because the ARCH and OS variable didn't have the right values to fetch the binaryen release.

Actually, in the container I have the following values :

``` 
# uname -m 
aarch64

# uname
Linux
```

With these values, the script tried to retrieve the following release :

`https://github.com/WebAssembly/binaryen/releases/download/version_116/binaryen-version_116-arm64-linux.tar.gz`

But, in the binaryen's list, I only find a version of arm64 for macOS. 

To patch the installation script in this case, we can choose to download the x86 version, which can of course run on an arm architecture.
