### PR TITLE
HTTP headers are never sent with the HTTP Client API

### DIFF
--- a/crates/core/src/globals.rs
+++ b/crates/core/src/globals.rs
@@ -206,7 +206,7 @@ fn build_http_object(context: &JSContextRef) -> anyhow::Result<JSValueRef> {
                 if !headers.is_object() {
                     bail!("Expected headers to be an object");
                 }
-                if !headers.is_object() {
+                if headers.is_object() {
                     let mut header_values = headers.properties()?;
                     loop {
                         let key = header_values.next_key()?;


### PR DESCRIPTION
When using the HTTP Client API from a JS plugin like this:

```javascript
const task = {
  "userId":1, 
  "id":2345,
  "title":"title",
  "completed":false
};
const request = {
  method: "POST",
  url: "https://jsonplaceholder.typicode.com/todos",
  headers: {
    "Accept": "application/json",
    "Content-Type": "application/json",
  },
};

const response = Http.request(
  request, 
  JSON.stringify(task),
);
```

it appears that the headers were never sent, hence the target server not being able to parse the body correctly and creating an empty task.

This pull request fix this behavior