### PR TITLE
cleanup: include checks when parsing d.ts files to error when functions have the wrong number of parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ declare module 'extism:host' {
 }
 ```
 
-**Note:** These need to have this signature `(I64): I64` for now. We will work on making different function arities work next.
+**Note:** These functions may use any Wasm native types (`I32`, `I64`, `F32`, `F64`) and up to 5 arguments.
 
 To use these you need to use `Host.getFunctions()`:
 
@@ -272,7 +272,7 @@ function greet() {
 module.exports = { greet }
 ```
 
-**IMPORTANT:** Currently, a limitation in the js-pdk is that host functions must have 1 `I64` pointer param and 1 `I64` pointer result. We enforce this through validation of the typescript interface file.
+**IMPORTANT:** Currently, a limitation in the js-pdk is that host functions may only have up to 5 arguments.
 
 
 ## Using with a bundler

--- a/crates/cli/src/ts_parser.rs
+++ b/crates/cli/src/ts_parser.rs
@@ -112,6 +112,9 @@ fn parse_user_interface(i: &TsInterfaceDecl) -> Result<Interface> {
                     let t = typ.unwrap().type_ann;
                     param_type(&mut params, vn, &t)?;
                 }
+                if params.len() > 5 {
+                    anyhow::bail!("Host functions only support up to 5 arguments");
+                }
                 if let Some(return_type) = &t.type_ann {
                     result_type(&mut results, &return_type.type_ann)?;
                 }
@@ -184,6 +187,9 @@ fn parse_module_decl(tsmod: &TsModuleDecl) -> Result<Interface> {
                                     param_type(&mut params, &name, &ann.type_ann)?;
                                 }
                             }
+                        }
+                        if params.len() > 0 {
+                            anyhow::bail!("Plugin functions should not accept any parameters");
                         }
                         let signature = Signature {
                             name,

--- a/crates/cli/src/ts_parser.rs
+++ b/crates/cli/src/ts_parser.rs
@@ -188,9 +188,6 @@ fn parse_module_decl(tsmod: &TsModuleDecl) -> Result<Interface> {
                                 }
                             }
                         }
-                        if params.len() > 0 {
-                            anyhow::bail!("Plugin functions should not accept any parameters");
-                        }
                         let signature = Signature {
                             name,
                             params,


### PR DESCRIPTION
- Returns an error when host  functions have more than 5 params 
- Updates limitations in README