### PR TITLE
fix: use homebrew to install wasm-merge on mac

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,31 +37,35 @@ if ! which "wasm-merge" > /dev/null || ! which "wasm-opt" > /dev/null; then
     ARCH="x86_64"
   fi
 
-  if [ ! -e "binaryen-$BINARYEN_TAG-$ARCH-$OS.tar.gz" ]; then
-    echo 'Downloading binaryen...'
-    curl -L -O "https://github.com/WebAssembly/binaryen/releases/download/$BINARYEN_TAG/binaryen-$BINARYEN_TAG-$ARCH-$OS.tar.gz"
-  fi
-  rm -rf 'binaryen' "binaryen-$BINARYEN_TAG"
-  tar xf "binaryen-$BINARYEN_TAG-$ARCH-$OS.tar.gz"
-  mv "binaryen-$BINARYEN_TAG"/ binaryen/
-  sudo mkdir -p /usr/local/binaryen
-  if ! which 'wasm-merge' > /dev/null; then
-    echo "Installing wasm-merge..."
-    rm -f /usr/local/binaryen/wasm-merge
-    sudo mv binaryen/bin/wasm-merge /usr/local/binaryen/wasm-merge
-    sudo ln -s /usr/local/binaryen/wasm-merge /usr/local/bin/wasm-merge
+  if [ $OS = "macos" ]; then
+    echo "Installing binaryen and wasm-merge using homebrew"
+    brew install binaryen
   else
-    echo "wasm-merge is already installed"
+    if [ ! -e "binaryen-$BINARYEN_TAG-$ARCH-$OS.tar.gz" ]; then
+      echo 'Downloading binaryen...'
+      curl -L -O "https://github.com/WebAssembly/binaryen/releases/download/$BINARYEN_TAG/binaryen-$BINARYEN_TAG-$ARCH-$OS.tar.gz"
+    fi
+    rm -rf 'binaryen' "binaryen-$BINARYEN_TAG"
+    tar xf "binaryen-$BINARYEN_TAG-$ARCH-$OS.tar.gz"
+    mv "binaryen-$BINARYEN_TAG"/ binaryen/
+    sudo mkdir -p /usr/local/binaryen
+    if ! which 'wasm-merge' > /dev/null; then
+      echo "Installing wasm-merge..."
+      rm -f /usr/local/binaryen/wasm-merge
+      sudo mv binaryen/bin/wasm-merge /usr/local/binaryen/wasm-merge
+      sudo ln -s /usr/local/binaryen/wasm-merge /usr/local/bin/wasm-merge
+    else
+      echo "wasm-merge is already installed"
+    fi
+    if ! which 'wasm-opt' > /dev/null; then
+      echo "Installing wasm-opt..."
+      rm -f /usr/local/bin/wasm-opt
+      sudo mv binaryen/bin/wasm-opt /usr/local/binaryen/wasm-opt
+      sudo ln -s /usr/local/binaryen/wasm-opt /usr/local/bin/wasm-opt
+    else
+      echo "wasm-opt is already installed"
+    fi
   fi
-  if ! which 'wasm-opt' > /dev/null; then
-    echo "Installing wasm-opt..."
-    rm -f /usr/local/bin/wasm-opt
-    sudo mv binaryen/bin/wasm-opt /usr/local/binaryen/wasm-opt
-    sudo ln -s /usr/local/binaryen/wasm-opt /usr/local/bin/wasm-opt
-  else
-    echo "wasm-opt is already installed"
-  fi
-
 else
   echo "wasm-merge and wasm-opt are already installed"
 fi


### PR DESCRIPTION
Installing wasm-merge this way doesn't seem to work on mac because binaryen is dynamically linked. So we will use homebrew instead.