### PR TITLE
Change prelude format to iife

### DIFF
--- a/crates/core/src/prelude/esbuild.js
+++ b/crates/core/src/prelude/esbuild.js
@@ -5,7 +5,6 @@ esbuild
     entryPoints: ["src/index.ts"],
     outdir: "dist",
     bundle: true,
-    sourcemap: true,
     minify: true,
     format: "iife", 
     target: ["es2020"], // don't go over es2020 because quickjs doesn't support it

--- a/crates/core/src/prelude/esbuild.js
+++ b/crates/core/src/prelude/esbuild.js
@@ -7,6 +7,6 @@ esbuild
     bundle: true,
     sourcemap: true,
     minify: true,
-    format: "cjs", // needs to be CJS for now
+    format: "iife", 
     target: ["es2020"], // don't go over es2020 because quickjs doesn't support it
   });


### PR DESCRIPTION
I ran into a headscratcher where my plugin worked without esbuild minification, but not when it was enabled. It would crash hard complaining something wasn't a function and sometimes it wasn't a constructor instead.

After some hours of debugging, it turns out the minification would cause a minified runtime global variable to be redeclared, so when the runtime tried to use its variable it would explode. Note while I say global, I mean all the variables meant to be locally scoped as well, as when the format is cjs, esbuild assume the code will run in its own scope so it won't isolate top-level variables. 

It isn't guaranteed to always cause issues, as usually shadowing a variable isn't a problem, but I'm guessing function hoisting complicated it in my case.

There should be no downside to this change, as it has no exports anyway and all the intentional globals are declared by modifying globalThis already.

---

Oh and disabled the sourcemap too, because it's completely unused anyway.