### PR TITLE
Update console.log implementation to support multiple params

### DIFF
--- a/crates/core/src/globals.rs
+++ b/crates/core/src/globals.rs
@@ -69,35 +69,39 @@ extern "C" {
     ) -> u64;
 }
 
+fn get_args_as_str(args: &[JSValueRef]) -> anyhow::Result<String> {
+    args.iter()
+        .map(|arg| arg.as_str())
+        .collect::<Result<Vec<&str>, _>>()
+        .map(|vec| vec.join(" "))
+        .context("Failed to convert args to string")
+}
+
 fn build_console_object(context: &JSContextRef) -> anyhow::Result<JSValueRef> {
     let console_debug_callback = context.wrap_callback(
         |_ctx: &JSContextRef, _this: JSValueRef, args: &[JSValueRef]| {
-            let stmt = args.first().ok_or(anyhow!("Need at least one arg"))?;
-            let stmt = stmt.as_str()?;
+            let stmt = get_args_as_str(args)?;
             debug!("{}", stmt);
             Ok(JSValue::Undefined)
         },
     )?;
     let console_info_callback = context.wrap_callback(
         |_ctx: &JSContextRef, _this: JSValueRef, args: &[JSValueRef]| {
-            let stmt = args.first().ok_or(anyhow!("Need at least one arg"))?;
-            let stmt = stmt.as_str()?;
+            let stmt = get_args_as_str(args)?;
             info!("{}", stmt);
             Ok(JSValue::Undefined)
         },
     )?;
     let console_warn_callback = context.wrap_callback(
         |_ctx: &JSContextRef, _this: JSValueRef, args: &[JSValueRef]| {
-            let stmt = args.first().ok_or(anyhow!("Need at least one arg"))?;
-            let stmt = stmt.as_str()?;
+            let stmt = get_args_as_str(args)?;
             warn!("{}", stmt);
             Ok(JSValue::Undefined)
         },
     )?;
     let console_error_callback = context.wrap_callback(
         |_ctx: &JSContextRef, _this: JSValueRef, args: &[JSValueRef]| {
-            let stmt = args.first().ok_or(anyhow!("Need at least one arg"))?;
-            let stmt = stmt.as_str()?;
+            let stmt = get_args_as_str(args)?;
             error!("{}", stmt);
             Ok(JSValue::Undefined)
         },


### PR DESCRIPTION
# Issue Summary
This PR fixes a couple of incompatibilities between the console.debug/log/warn/error statements.  `console.log("a", "b", "c");` in the exits js-pdk does not output the expected `a b c` but just outputs `a`.  also, an empty console.log errors out, but it normally is a no-op.


# Test script
```
  console.debug();
  console.debug("debug: single console statement");
  console.debug("debug:", "multiple", "console", "statements");

  console.log();
  console.log("log: single console statement");
  console.log("log:", "multiple", "console", "statements");

  console.warn();
  console.warn("warn: single console statement");
  console.warn("warn:", "multiple", "console", "statements");

  console.error();
  console.error("error: single console statement");
  console.error("error:", "multiple", "console", "statements");
```

# Output in chrome devtools
![image](https://github.com/extism/js-pdk/assets/96382050/0c7692fe-10c8-4d7c-b172-12affc4083ff)


# Output in current js-pdk
```
2024/05/26 11:18:19 Calling function : greet
Error: Uncaught InternalError: Need at least one arg
    at greet (script.js:43)
```
note that the no-op behavior of an empty call is not present here and it instead errors.

# Output in current js-pdk with empty calls removed
```
2024/05/26 11:19:26 debug: single console statement
2024/05/26 11:19:26 debug:
2024/05/26 11:19:26 log: single console statement
2024/05/26 11:19:26 log:
2024/05/26 11:19:26 warn: single console statement
2024/05/26 11:19:26 warn:
2024/05/26 11:19:26 error: single console statement
2024/05/26 11:19:26 error:
```
note the multi-statement lines do not print all arguments.

# Output with the code change from the PR (including empty statements)
```
024/05/26 11:23:07 Calling function : greet
2024/05/26 11:23:08 debug: single console statement
2024/05/26 11:23:08 debug: multiple console statements
2024/05/26 11:23:08 log: single console statement
2024/05/26 11:23:08 log: multiple console statements
2024/05/26 11:23:08 warn: single console statement
2024/05/26 11:23:08 warn: multiple console statements
2024/05/26 11:23:08 error: single console statement
2024/05/26 11:23:08 error: multiple console statements
```

note that the empty statements are properly no-ops, and the multiple args are properly printed.

# 
