### PR TITLE
feat(release): add windows cli release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,14 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: linux
+            os: ubuntu-latest
+          - name: windows
+            os: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -24,7 +31,7 @@ jobs:
         with:
           python-version: '3.12' 
 
-      - name: Update deps
+      - name: Update deps (Linux)
         run: |
           ./install-wasi-sdk.sh
           go install github.com/extism/cli/extism@latest
@@ -34,10 +41,35 @@ jobs:
           tar xvzf binaryen.tar.gz
           sudo cp binaryen-version_116/bin/wasm-merge /usr/local/bin
           sudo cp binaryen-version_116/bin/wasm-opt /usr/local/bin
+        if: runner.os != 'Windows'
 
-      - name: Run Tests
+      - name: Update deps (Windows)
+        run: |
+          powershell -executionpolicy bypass -File .\install-wasi-sdk.ps1
+          go install github.com/extism/cli/extism@latest
+          Remove-Item -Recurse -Path "c:\Program files\Binaryen" -Force -ErrorAction SilentlyContinue > $null 2>&1
+          New-Item -ItemType Directory -Force -Path "c:\Program files\Binaryen" -ErrorAction Stop > $null 2>&1
+          Invoke-WebRequest -Uri "https://github.com/WebAssembly/binaryen/releases/download/version_116/binaryen-version_116-x86_64-windows.tar.gz" -OutFile "$env:TMP\binaryen-version_116-x86_64-windows.tar.gz"
+          7z x "$env:TMP\binaryen-version_116-x86_64-windows.tar.gz" -o"$env:TMP\" >$null  2>&1
+          7z x -ttar "$env:TMP\binaryen-version_116-x86_64-windows.tar" -o"$env:TMP\" >$null  2>&1
+          Copy-Item -Path "$env:TMP\binaryen-version_116\bin\wasm-opt.exe" -Destination "c:\Program files\Binaryen" -ErrorAction Stop > $null 2>&1
+          Copy-Item -Path "$env:TMP\binaryen-version_116\bin\wasm-merge.exe" -Destination "c:\Program files\Binaryen" -ErrorAction Stop > $null 2>&1
+        if: runner.os == 'Windows'
+
+      - name: Run Tests (Linux)
         env:
           QUICKJS_WASM_SYS_WASI_SDK_PATH: "${{ github.workspace }}/wasi-sdk"
         run: |
           make
           make test
+        if: runner.os != 'Windows'
+
+      - name: Run Tests (Windows)
+        env:
+          QUICKJS_WASM_SYS_WASI_SDK_PATH: "${{ github.workspace }}/wasi-sdk"
+        run: |
+          set PATH="c:\Program files\Binaryen\";%PATH%
+          make
+          make test
+        shell: cmd
+        if: runner.os == 'Windows'

--- a/.github/workflows/ci_install.yml
+++ b/.github/workflows/ci_install.yml
@@ -4,11 +4,25 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: linux
+            os: ubuntu-latest
+          - name: windows
+            os: windows-latest
     steps:
     - uses: actions/checkout@v2
 
-    - name: Test Install Script
+    - name: Test Install Script (Linux)
       run: |
         sh install.sh
         extism-js --version
+      if: runner.os != 'Windows'
+
+    - name: Test Install Script (Windows)
+      run: |
+        powershell -executionpolicy bypass -File .\install-windows.ps1
+        extism-js --version
+      if: runner.os == 'Windows'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   compile_core:
     name: Compile Core
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
 
@@ -21,11 +21,21 @@ jobs:
           target: wasm32-wasi
           default: true
 
+      - name: Get wasm-opt
+        run: |
+          curl -L https://github.com/WebAssembly/binaryen/releases/download/version_116/binaryen-version_116-x86_64-linux.tar.gz > binaryen.tar.gz
+          tar xvzf binaryen.tar.gz
+          sudo cp binaryen-version_116/bin/wasm-opt /usr/local/bin
+          sudo chmod +x /usr/local/bin/wasm-opt
+
       - name: Install wasi-sdk
         run: make download-wasi-sdk
 
       - name: Make core
         run: make core
+
+      - name: Opt core
+        run: wasm-opt --enable-reference-types --enable-bulk-memory --strip -O3 target/wasm32-wasi/release/js_pdk_core.wasm -o target/wasm32-wasi/release/js_pdk_core.wasm
 
       - name: Upload core binary to artifacts
         uses: actions/upload-artifact@v2
@@ -64,11 +74,16 @@ jobs:
             asset_name: extism-js-aarch64-macos-${{ github.event.release.tag_name }}
             shasum_cmd: shasum -a 256
             target: aarch64-apple-darwin
-          # - name: windows
-          #   os: windows-latest
-          #   path: target\release\extism-js.exe
-          #   asset_name: extism-js-x86_64-windows-${{ github.event.release.tag_name }}
-          #   shasum_cmd: sha256sum
+          - name: windows
+            os: windows-latest
+            path: target\x86_64-pc-windows-msvc\release\extism-js.exe
+            asset_name: extism-js-x86_64-windows-${{ github.event.release.tag_name }}
+            target: x86_64-pc-windows-msvc
+          - name: windows-arm64
+            os: windows-latest
+            path: target\aarch64-pc-windows-msvc\release\extism-js.exe
+            asset_name: extism-js-aarch64-windows-${{ github.event.release.tag_name }}
+            target: aarch64-pc-windows-msvc
 
     steps:
       - uses: actions/checkout@v1
@@ -121,8 +136,14 @@ jobs:
           asset_name: ${{ matrix.asset_name }}.gz
           asset_content_type: application/gzip
 
-      - name: Generate asset hash
+      - name: Generate asset hash (Linux/MacOS)
         run: ${{ matrix.shasum_cmd }} ${{ matrix.asset_name }}.gz | awk '{ print $1 }' > ${{ matrix.asset_name }}.gz.sha256
+        if: runner.os != 'Windows'
+
+      - name: Generate asset hash (Windows)
+        run: Get-FileHash -Path ${{ matrix.asset_name }}.gz -Algorithm SHA256 | Select-Object -ExpandProperty Hash > ${{ matrix.asset_name }}.gz.sha256
+        shell: pwsh
+        if: runner.os == 'Windows'
 
       - name: Upload asset hash to artifacts
         uses: actions/upload-artifact@v2

--- a/README.md
+++ b/README.md
@@ -24,11 +24,20 @@ We release the compiler as native binaries you can download and run. Check the [
 
 ## Install Script
 
+### Linux, macOS :
 ```bash
 curl -O https://raw.githubusercontent.com/extism/js-pdk/main/install.sh
 sh install.sh
 ```
 
+### Windows
+>7zip is required, you can find it [here](https://www.7-zip.org/).
+
+Open the Command Prompt as Administrator, then run :
+```bash
+powershell Invoke-WebRequest -Uri https://raw.githubusercontent.com/extism/js-pdk/main/install-windows.ps1 -OutFile install-windows.ps1
+powershell -executionpolicy bypass -File .\install-windows.ps1
+```
 > *Note*: [Binaryen](https://github.com/WebAssembly/binaryen), specifically the `wasm-merge` and `wasm-opt` tools
 > are required as a dependency. We will try to package this up eventually but for now it must be reachable
 > on your machine. You can install on mac with `brew install binaryen` or see their [releases page](https://github.com/WebAssembly/binaryen/releases).
@@ -450,6 +459,8 @@ Before compiling the compiler, you need to install prerequisites.
 2. Install the WASI target platform via `rustup target add --toolchain stable wasm32-wasi`
 3. Install the wasi sdk using the makefile command: `make download-wasi-sdk`
 4. Install [CMake](https://cmake.org/install/) (on macOS with homebrew, `brew install cmake`)
+6. Install [Binaryen](https://github.com/WebAssembly/binaryen/) and add it's install location to your PATH (only wasm-opt is required for build process)
+5. Install [7zip](https://www.7-zip.org/)(only for Windows)
 
 
 ### Compiling from source

--- a/examples/bundled/package-lock.json
+++ b/examples/bundled/package-lock.json
@@ -10,6 +10,7 @@
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@extism/js-pdk": "../../crates/core/src/prelude",
+        "cross-env": "^7.0.3",
         "esbuild": "^0.19.6",
         "typescript": "^5.3.2"
       }
@@ -384,6 +385,38 @@
       "resolved": "../../crates/core/src/prelude",
       "link": true
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.19.6",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.6.tgz",
@@ -421,6 +454,42 @@
         "@esbuild/win32-x64": "0.19.6"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
@@ -432,6 +501,21 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     }
   }

--- a/examples/bundled/package.json
+++ b/examples/bundled/package.json
@@ -4,13 +4,14 @@
   "description": "",
   "main": "src/index.ts",
   "scripts": {
-    "build": "node esbuild.js && ../../target/release/extism-js dist/index.js -i src/index.d.ts -o ../bundled.wasm"
+    "build": "cross-env NODE_ENV=production node esbuild.js && cross-env ../../target/release/extism-js dist/index.js -i src/index.d.ts -o ../bundled.wasm"
   },
   "keywords": [],
   "author": "",
   "license": "BSD-3-Clause",
   "devDependencies": {
     "@extism/js-pdk": "../../crates/core/src/prelude",
+    "cross-env": "^7.0.3",
     "esbuild": "^0.19.6",
     "typescript": "^5.3.2"
   }

--- a/examples/kitchen-sink/package-lock.json
+++ b/examples/kitchen-sink/package-lock.json
@@ -10,6 +10,7 @@
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@extism/js-pdk": "../../crates/core/src/prelude",
+        "cross-env": "^7.0.3",
         "esbuild": "^0.19.6",
         "typescript": "^5.3.2"
       }
@@ -400,6 +401,38 @@
       "resolved": "../../crates/core/src/prelude",
       "link": true
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.19.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
@@ -438,6 +471,42 @@
         "@esbuild/win32-x64": "0.19.12"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
@@ -449,6 +518,21 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     }
   }

--- a/examples/kitchen-sink/package.json
+++ b/examples/kitchen-sink/package.json
@@ -4,13 +4,14 @@
   "description": "",
   "main": "src/index.ts",
   "scripts": {
-    "build": "node esbuild.js && ../../target/release/extism-js dist/index.js -i src/index.d.ts -o ../kitchen-sink.wasm"
+    "build": "cross-env NODE_ENV=production node esbuild.js && cross-env ../../target/release/extism-js dist/index.js -i src/index.d.ts -o ../kitchen-sink.wasm"
   },
   "keywords": [],
   "author": "",
   "license": "BSD-3-Clause",
   "devDependencies": {
     "@extism/js-pdk": "../../crates/core/src/prelude",
+    "cross-env": "^7.0.3",
     "esbuild": "^0.19.6",
     "typescript": "^5.3.2"
   }

--- a/examples/react/package-lock.json
+++ b/examples/react/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@extism/js-pdk": "../../crates/core/src/prelude",
         "@types/react": "^18.3.1",
+        "cross-env": "^7.0.3",
         "esbuild": "^0.19.6",
         "typescript": "^5.3.2"
       }
@@ -404,6 +405,38 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -447,6 +480,12 @@
         "@esbuild/win32-x64": "0.19.6"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -461,6 +500,15 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/react": {
@@ -495,6 +543,27 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
@@ -506,6 +575,21 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     }
   }

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "src/index.tsx",
   "scripts": {
-    "build": "node esbuild.js && ../../target/release/extism-js dist/index.js -i src/index.d.ts -o ../react.wasm"
+    "build": "cross-env NODE_ENV=production node esbuild.js && cross-env ../../target/release/extism-js dist/index.js -i src/index.d.ts -o ../react.wasm"
   },
   "keywords": [],
   "author": "",
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@extism/js-pdk": "../../crates/core/src/prelude",
     "@types/react": "^18.3.1",
+    "cross-env": "^7.0.3",
     "esbuild": "^0.19.6",
     "typescript": "^5.3.2"
   },

--- a/install-wasi-sdk.ps1
+++ b/install-wasi-sdk.ps1
@@ -1,0 +1,43 @@
+#!/usr/bin/env pwsh
+
+$7z= "7z"
+if (-not (Get-Command $7z -ErrorAction SilentlyContinue)){
+  $7z= "$env:Programfiles\7-Zip\7z.exe"
+}
+$tempPath= "$env:TEMP"
+
+
+if ((Split-Path -Leaf (Get-Location)) -ne "js-pdk") {
+    Write-Error "Run this inside the root of the js-pdk repo"
+    exit 1
+}
+
+if ($env:QUICKJS_WASM_SYS_WASI_SDK_PATH) {
+    if (-Not (Test-Path -Path $env:QUICKJS_WASM_SYS_WASI_SDK_PATH)) {
+        Write-Error "Download the wasi-sdk to $env:QUICKJS_WASM_SYS_WASI_SDK_PATH"
+        exit 1
+    }
+    exit 0
+}
+
+$PATH_TO_SDK = "wasi-sdk"
+if (-Not (Test-Path -Path $PATH_TO_SDK)) {
+    $VERSION_MAJOR = "12"
+    $VERSION_MINOR = "0"
+    $url = "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-$VERSION_MAJOR/wasi-sdk-$VERSION_MAJOR.$VERSION_MINOR-mingw.tar.gz"
+    Invoke-WebRequest -Uri $url -OutFile "$tempPath\wasi-sdk-$VERSION_MAJOR.$VERSION_MINOR-mingw.tar.gz" 
+
+    New-Item -ItemType Directory -Path $PATH_TO_SDK | Out-Null
+
+    & $7z x "$tempPath\wasi-sdk-$VERSION_MAJOR.$VERSION_MINOR-mingw.tar.gz" -o"$tempPath" | Out-Null
+    & $7z x -ttar "$tempPath\wasi-sdk-$VERSION_MAJOR.$VERSION_MINOR-mingw.tar" -o"$tempPath" | Out-Null
+
+    Get-ChildItem -Path "$tempPath\wasi-sdk-$VERSION_MAJOR.$VERSION_MINOR" | ForEach-Object {
+        Move-Item -Path $_.FullName -Destination $PATH_TO_SDK -Force | Out-Null
+    }
+
+    Remove-Item -Path "$tempPath\wasi-sdk-$VERSION_MAJOR.$VERSION_MINOR" -Recurse -Force | Out-Null
+    Remove-Item -Path "$tempPath\wasi-sdk-$VERSION_MAJOR.$VERSION_MINOR-mingw.tar" -Recurse -Force | Out-Null
+    Remove-Item -Path "$tempPath\wasi-sdk-$VERSION_MAJOR.$VERSION_MINOR-mingw.tar.gz" -Recurse -Force | Out-Null
+
+}

--- a/install-windows.ps1
+++ b/install-windows.ps1
@@ -1,0 +1,61 @@
+#!/usr/bin/env pwsh
+
+$TAG= "v1.0.0-rc10"
+$BINARYEN_TAG= "version_116"
+$extismPath="$env:Programfiles\Extism"
+$binaryenPath="$env:Programfiles\Binaryen"
+$7z= "7z"
+if (-not (Get-Command $7z -ErrorAction SilentlyContinue)){
+  $7z= "$env:Programfiles\7-Zip\7z.exe"
+}
+$tempPath= "$env:TEMP"
+
+try {
+
+    $ARCH = (Get-CimInstance Win32_Processor).Architecture
+    switch ($ARCH) {
+        9 { $ARCH = "x86_64" }
+        12 { $ARCH = "aarch64" }
+        default { Write-Host "unknown arch: $ARCH" -ForegroundColor Red; exit 1 }
+    }
+    Write-Host "ARCH is $ARCH."
+
+    Write-Host "Downloading extism-js version $TAG."
+    $TMPGZ = [System.IO.Path]::GetTempFileName()
+    Invoke-WebRequest -Uri "https://github.com/extism/js-pdk/releases/download/$TAG/extism-js-$ARCH-windows-$TAG.gz" -OutFile "$TMPGZ"
+
+    Write-Host "Installing extism-js."
+    Remove-Item -Recurse -Path "$extismPath" -Force -ErrorAction SilentlyContinue | Out-Null
+    New-Item -ItemType Directory -Force -Path $extismPath -ErrorAction Stop | Out-Null
+    & $7z x "$TMPGZ" -o"$extismPath" >$null  2>&1
+
+    if ($env:Path -split ';' -notcontains $extismPath) {
+      [System.Environment]::SetEnvironmentVariable("Path", "$extismPath;$env:PATH", [System.EnvironmentVariableTarget]::Machine)
+    }
+
+    if (-not (Get-Command "wasm-merge" -ErrorAction SilentlyContinue) -or -not (Get-Command "wasm-opt" -ErrorAction SilentlyContinue)) {
+    
+        Write-Output "Missing Binaryen tool(s)."
+        Remove-Item -Recurse -Path "$binaryenPath" -Force -ErrorAction SilentlyContinue | Out-Null
+        New-Item -ItemType Directory -Force -Path $binaryenPath -ErrorAction Stop | Out-Null
+        
+        Write-Output "Downloading Binaryen version $BINARYEN_TAG."
+        Remove-Item -Recurse -Path "$tempPath\binaryen-*" -Force -ErrorAction SilentlyContinue | Out-Null
+        Invoke-WebRequest -Uri "https://github.com/WebAssembly/binaryen/releases/download/$BINARYEN_TAG/binaryen-$BINARYEN_TAG-$ARCH-windows.tar.gz" -OutFile "$tempPath\binaryen-$BINARYEN_TAG-$ARCH-windows.tar.gz"
+
+    
+        Write-Output "Installing Binaryen."
+        & $7z x "$tempPath\binaryen-$BINARYEN_TAG-$ARCH-windows.tar.gz" -o"$tempPath" >$null  2>&1
+        & $7z x -ttar "$tempPath\binaryen-$BINARYEN_TAG-$ARCH-windows.tar" -o"$tempPath" >$null  2>&1
+        Copy-Item "$tempPath\binaryen-$BINARYEN_TAG\bin\wasm-opt.exe" -Destination "$binaryenPath" -ErrorAction Stop | Out-Null
+        Copy-Item "$tempPath\binaryen-$BINARYEN_TAG\bin\wasm-merge.exe" -Destination "$binaryenPath" -ErrorAction Stop | Out-Null
+    }
+
+    if ($env:Path -split ';' -notcontains $binaryenPath) {
+      [System.Environment]::SetEnvironmentVariable("Path", "$binaryenPath;$env:PATH", [System.EnvironmentVariableTarget]::Machine)
+    }
+    Write-Output "Install done !"
+}catch {
+  Write-Output "Install Failed: $_.Exception.Message"
+  exit 1
+}


### PR DESCRIPTION
Closes #25 

This PR enable windows support for js-pdk cli.

The approach is minimalist and use line-by-line translation for the existing configs/code to facilitate the change validation. This have an impact on performance in some case (Test CI for windows) takes ~15min, some rework would be need to reduce the build time but I hope this would be fine for now. 

As discussed in [discord](https://discord.com/channels/1011124058408112148/1062468347851178165/1242975938116063302), wasm-opt v117 seems to have a [bug](https://github.com/WebAssembly/binaryen/issues/6639). 
In order to avoid running into it :
- In CI release worker, make sure js_pdk_core.wasm is optimized before packing it in the released binaries. *(1)
- In manual build process (Makefile), make sure js_pdk_core.wasm is optimized before packing it. *(2)
- We need for now to freeze Binaryen's version to 116 and not upgrade it.

CI 'Install script for windows' will probably fail first run as it will try to install a version that doesn't exist yet `windows v1.0.0-rc10`


*(1) Indirect positive consequence of this, cli binary size is reduced slightly AND I observed 2x speed improvement with versions having an already optimized core. 
*(2) This doesn't grantee avoiding the issue, if Binaryen v117 is installed beforehand. Overall I don't think this is a high probability case (Windows manual build + Binaryen v117 already installed)

> You can already check cli files for windows (x86_64 and arm64) https://github.com/mtb0x1/js-pdk/releases