### PR TITLE
fix(windows): install script, ci test install and documentation

### DIFF
--- a/.github/workflows/ci_install.yml
+++ b/.github/workflows/ci_install.yml
@@ -28,5 +28,6 @@ jobs:
 
     - name: Test Install Script Part2 (Windows)
       run: |
+        $env:Path = "C:\Program Files\Extism\;C:\Program Files\Binaryen\;" + $env:Path
         extism-js --version
       if: runner.os == 'Windows'

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Open the Command Prompt as Administrator, then run :
 powershell Invoke-WebRequest -Uri https://raw.githubusercontent.com/extism/js-pdk/main/install-windows.ps1 -OutFile install-windows.ps1
 powershell -executionpolicy bypass -File .\install-windows.ps1
 ```
+This will install extism-js and binaryen dependency under `Program File` folder (i.e. C:\Program Files\Binaryen and C:\Program Files\Extism). You must add these paths to your PATH environment variable.
 
 ### Testing the Install
 

--- a/install-windows.ps1
+++ b/install-windows.ps1
@@ -29,10 +29,6 @@ try {
     New-Item -ItemType Directory -Force -Path $extismPath -ErrorAction Stop | Out-Null
     & $7z x "$TMPGZ" -o"$extismPath" >$null  2>&1
 
-    if ($env:Path -split ';' -notcontains $extismPath) {
-      [System.Environment]::SetEnvironmentVariable("Path", "$extismPath;$env:PATH", [System.EnvironmentVariableTarget]::Machine)
-    }
-
     if (-not (Get-Command "wasm-merge" -ErrorAction SilentlyContinue) -or -not (Get-Command "wasm-opt" -ErrorAction SilentlyContinue)) {
     
         Write-Output "Missing Binaryen tool(s)."
@@ -51,9 +47,6 @@ try {
         Copy-Item "$tempPath\binaryen-$BINARYEN_TAG\bin\wasm-merge.exe" -Destination "$binaryenPath" -ErrorAction Stop | Out-Null
     }
 
-    if ($env:Path -split ';' -notcontains $binaryenPath) {
-      [System.Environment]::SetEnvironmentVariable("Path", "$binaryenPath;$env:PATH", [System.EnvironmentVariableTarget]::Machine)
-    }
     Write-Output "Install done !"
 }catch {
   Write-Output "Install Failed: $_.Exception.Message"


### PR DESCRIPTION
The old version attempts to append Path during the install script. The result is flaky and doesn't work reliably : 
- Doesn't seem to persist value in local settings.
- Depending on the console type (cmd or powershell), the result is different
- CI vs local whole machine vs User profile ...

This fix removes the auto append and updates install instructions to leave the option to the user.
