### PR TITLE
chore: modify mem find to return js undefined

### DIFF
--- a/crates/core/src/globals.rs
+++ b/crates/core/src/globals.rs
@@ -491,7 +491,7 @@ fn build_memory(context: &JSContextRef) -> anyhow::Result<JSValueRef> {
             };
 
             let Some(m) = extism_pdk::Memory::find(ptr as u64) else {
-                bail!("Offset did not represent a valid block of memory (offset={ptr:x})");
+                return Ok(JSValue::Undefined);
             };
             let mut mem = HashMap::new();
 

--- a/crates/core/src/prelude/src/memory.ts
+++ b/crates/core/src/prelude/src/memory.ts
@@ -76,6 +76,9 @@ Memory.allocFloat64 = function(this: Memory, i) {
 
 Memory.find = function(offset) {
   const memData = Memory._find(offset);
+  if (memData === undefined) {
+    return undefined;  
+  }
   return new MemoryHandle(memData.offset, memData.len);
 };
 


### PR DESCRIPTION
Realizing that there are some places where having control of the behavior when a zero-offset memory handle would otherwise cause a panic/throw. This gives the caller control of how to interpret the result. 

For example, in the case of an `xtp-test-js` call output, I need to know that a call does not return any value.