### PR TITLE
Add flag to skip optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We release the compiler as native binaries you can download and run. Check the [
 
 ```bash
 curl -O https://raw.githubusercontent.com/extism/js-pdk/main/install.sh
-sh install.sh
+bash install.sh
 ```
 
 ### Windows
@@ -46,17 +46,26 @@ This will install extism-js and binaryen dependency under `Program File` folder 
 > are required as a dependency. We will try to package this up eventually but for now it must be reachable
 > on your machine. You can install on mac with `brew install binaryen` or see their [releases page](https://github.com/WebAssembly/binaryen/releases).
 
-Then run command with no args to see the help:
+Then run command with `-h` to see the help:
 
 ```
-extism-js
-error: The following required arguments were not provided:
-    <input-js>
+extism-js 1.1.1
+Extism JavaScript PDK Plugin Compiler
 
 USAGE:
-    extism-js <input-js> -i <interface-file> -o <output>
+    extism-js [FLAGS] [OPTIONS] <input-js>
 
-For more information try --help
+FLAGS:
+    -h, --help        Prints help information
+        --skip-opt    Skip final optimization pass
+    -V, --version     Prints version information
+
+OPTIONS:
+    -i <interface-file>         [default: index.d.ts]
+    -o <output>                 [default: index.wasm]
+
+ARGS:
+    <input-js>
 ```
 
 > **Note**: If you are using mac, you may need to tell your security system this unsigned binary is fine. If you think this is dangerous, or can't get it to work, see the "compile from source" section below.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -25,6 +25,7 @@ fn main() -> Result<()> {
         .init();
 
     let opts = Options::from_args();
+
     if opts.core {
         opt::Optimizer::new(CORE)
             .wizen(true)
@@ -120,7 +121,9 @@ fn main() -> Result<()> {
         bail!("wasm-merge failed. Couldn't merge shim");
     }
 
-    opt::optimize_wasm_file(opts.output)?;
+    if !opts.skip_opt {
+        opt::optimize_wasm_file(opts.output)?;
+    }
 
     Ok(())
 }

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -4,15 +4,31 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 #[structopt(name = "extism-js", about = "Extism JavaScript PDK Plugin Compiler")]
 pub struct Options {
-    #[structopt(parse(from_os_str))]
+    #[structopt(
+        parse(from_os_str),
+        about = "Input JS program for the plugin. Needs to be a single file."
+    )]
     pub input_js: PathBuf,
 
-    #[structopt(short = "i", parse(from_os_str), default_value = "index.d.ts")]
+    #[structopt(
+        short = "i",
+        parse(from_os_str),
+        default_value = "index.d.ts",
+        about = "d.ts file describing the plug-in interface."
+    )]
     pub interface_file: PathBuf,
 
-    #[structopt(short = "o", parse(from_os_str), default_value = "index.wasm")]
+    #[structopt(
+        short = "o",
+        parse(from_os_str),
+        default_value = "index.wasm",
+        about = "Ouput wasm file."
+    )]
     pub output: PathBuf,
 
-    #[structopt(short = "c")]
+    #[structopt(short = "c", about = "Include the core")]
     pub core: bool,
+
+    #[structopt(long = "--skip-opt", about = "Skip final optimization pass")]
+    pub skip_opt: bool,
 }


### PR DESCRIPTION
Pretty small change but makes the compilation faster if you want a faster iteration cycle. 

Without skip-opt:

```
[I] ben@dylibso ~/d/js-pdk (main)> time ./target/release/extism-js examples/simple_js/script.js -i examples/simple_js/script.d.ts -o examples/simple_js.wasm
[2024-10-16T15:48:41Z INFO  extism_js] parsed interface: 298.5µs
[2024-10-16T15:48:41Z INFO  extism_js] read user code: 38.417µs
[2024-10-16T15:48:41Z INFO  extism_js] concated user code: 3.209µs
[2024-10-16T15:48:41Z INFO  extism_js] command done: 60.358042ms
[2024-10-16T15:48:41Z INFO  extism_js] generated shims: 267.958µs
[2024-10-16T15:48:41Z INFO  extism_js] wasm merge check: 22.89325ms
[2024-10-16T15:48:41Z INFO  extism_js] wasm merge: 125.382209ms
[2024-10-16T15:48:42Z INFO  extism_js] wasm opt: 774.119041ms

________________________________________________________
Executed in  995.36 millis    fish           external
   usr time    4.16 secs      0.24 millis    4.16 secs
   sys time    0.08 secs      1.16 millis    0.08 secs

```

With skip-opt:

```
[I] ben@dylibso ~/d/js-pdk (main)> time ./target/release/extism-js examples/simple_js/script.js -i examples/simple_js/script.d.ts -o examples/simple_js.wasm --skip-opt
[2024-10-16T15:48:44Z INFO  extism_js] parsed interface: 298.333µs
[2024-10-16T15:48:44Z INFO  extism_js] read user code: 37.458µs
[2024-10-16T15:48:44Z INFO  extism_js] concated user code: 2.625µs
[2024-10-16T15:48:44Z INFO  extism_js] command done: 59.516458ms
[2024-10-16T15:48:44Z INFO  extism_js] generated shims: 245.542µs
[2024-10-16T15:48:44Z INFO  extism_js] wasm merge check: 23.005541ms
[2024-10-16T15:48:44Z INFO  extism_js] wasm merge: 125.184334ms

________________________________________________________
Executed in  219.40 millis    fish           external
   usr time  280.54 millis  175.00 micros  280.37 millis
   sys time   36.47 millis  812.00 micros   35.66 millis
```