### PR TITLE
fix: use BigInt for host function params

### DIFF
--- a/crates/core/src/globals.rs
+++ b/crates/core/src/globals.rs
@@ -39,10 +39,10 @@ pub fn inject_globals(context: &JSContext) -> anyhow::Result<()> {
 
         add_host_functions(this.clone()).map_err(|e| to_js_error(this.clone(), e))?;
 
-        this.eval("globalThis.module = {}; globalThis.module.exports = {}")?;
+        this.eval::<(), _>("globalThis.module = {}; globalThis.module.exports = {}")?;
         // need a *global* var for polyfills to work
-        this.eval("var global = globalThis")?;
-        this.eval(from_utf8(PRELUDE).map_err(rquickjs::Error::Utf8)?)?;
+        this.eval::<(), _>("var global = globalThis")?;
+        this.eval::<(), _>(from_utf8(PRELUDE).map_err(rquickjs::Error::Utf8)?)?;
 
         Ok::<_, rquickjs::Error>(())
     })?;
@@ -260,6 +260,7 @@ fn add_host_functions(this: Ctx<'_>) -> anyhow::Result<()> {
     if invoke_host.is_null() || invoke_host.is_undefined() {
         let host_invoke_func = Function::new(this.clone(), move |cx, args: Rest<Value<'_>>| {
             let func_id = args.first().unwrap().as_int().unwrap() as u32;
+            println!("Invoke host func: {func_id}");
             let len = args.len() - 1;
             match len {
                 0 => {
@@ -268,30 +269,100 @@ fn add_host_functions(this: Ctx<'_>) -> anyhow::Result<()> {
                     Ok(Value::new_float(cx, result as f64))
                 }
                 1 => {
-                    let ptr = args.get(1).unwrap().as_float().unwrap();
+                    let ptr = args
+                        .get(1)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
                     let result = unsafe { __invokeHostFunc_1_1(func_id, ptr as u64) };
                     Ok(Value::new_float(cx, result as f64))
                 }
                 2 => {
-                    let ptr = args.get(1).unwrap().as_float().unwrap();
-                    let ptr2 = args.get(2).unwrap().as_float().unwrap();
+                    let ptr = args
+                        .get(1)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
+                    let ptr2 = args
+                        .get(2)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
                     let result = unsafe { __invokeHostFunc_2_1(func_id, ptr as u64, ptr2 as u64) };
                     Ok(Value::new_float(cx, result as f64))
                 }
                 3 => {
-                    let ptr = args.get(1).unwrap().as_float().unwrap();
-                    let ptr2 = args.get(2).unwrap().as_float().unwrap();
-                    let ptr3 = args.get(3).unwrap().as_float().unwrap();
+                    let ptr = args
+                        .get(1)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
+                    let ptr2 = args
+                        .get(2)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
+                    let ptr3 = args
+                        .get(3)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
                     let result = unsafe {
                         __invokeHostFunc_3_1(func_id, ptr as u64, ptr2 as u64, ptr3 as u64)
                     };
                     Ok(Value::new_float(cx, result as f64))
                 }
                 4 => {
-                    let ptr = args.get(1).unwrap().as_float().unwrap();
-                    let ptr2 = args.get(2).unwrap().as_float().unwrap();
-                    let ptr3 = args.get(3).unwrap().as_float().unwrap();
-                    let ptr4 = args.get(4).unwrap().as_float().unwrap();
+                    let ptr = args
+                        .get(1)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
+                    let ptr2 = args
+                        .get(2)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
+                    let ptr3 = args
+                        .get(3)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
+                    let ptr4 = args
+                        .get(4)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
                     let result = unsafe {
                         __invokeHostFunc_4_1(
                             func_id,
@@ -304,11 +375,46 @@ fn add_host_functions(this: Ctx<'_>) -> anyhow::Result<()> {
                     Ok(Value::new_float(cx, result as f64))
                 }
                 5 => {
-                    let ptr = args.get(1).unwrap().as_float().unwrap();
-                    let ptr2 = args.get(2).unwrap().as_float().unwrap();
-                    let ptr3 = args.get(3).unwrap().as_float().unwrap();
-                    let ptr4 = args.get(4).unwrap().as_float().unwrap();
-                    let ptr5 = args.get(5).unwrap().as_float().unwrap();
+                    let ptr = args
+                        .get(1)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
+                    let ptr2 = args
+                        .get(2)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
+                    let ptr3 = args
+                        .get(3)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
+                    let ptr4 = args
+                        .get(4)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
+                    let ptr5 = args
+                        .get(5)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
                     let result = unsafe {
                         __invokeHostFunc_5_1(
                             func_id,

--- a/crates/core/src/globals.rs
+++ b/crates/core/src/globals.rs
@@ -441,25 +441,95 @@ fn add_host_functions(this: Ctx<'_>) -> anyhow::Result<()> {
                     unsafe { __invokeHostFunc_0_0(func_id) };
                 }
                 1 => {
-                    let ptr = args.get(1).unwrap().as_float().unwrap();
+                    let ptr = args
+                        .get(1)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
                     unsafe { __invokeHostFunc_1_0(func_id, ptr as u64) };
                 }
                 2 => {
-                    let ptr = args.get(1).unwrap().as_float().unwrap();
-                    let ptr2 = args.get(2).unwrap().as_float().unwrap();
+                    let ptr = args
+                        .get(1)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
+                    let ptr2 = args
+                        .get(2)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
                     unsafe { __invokeHostFunc_2_0(func_id, ptr as u64, ptr2 as u64) };
                 }
                 3 => {
-                    let ptr = args.get(1).unwrap().as_float().unwrap();
-                    let ptr2 = args.get(2).unwrap().as_float().unwrap();
-                    let ptr3 = args.get(3).unwrap().as_float().unwrap();
+                    let ptr = args
+                        .get(1)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
+                    let ptr2 = args
+                        .get(2)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
+                    let ptr3 = args
+                        .get(3)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
                     unsafe { __invokeHostFunc_3_0(func_id, ptr as u64, ptr2 as u64, ptr3 as u64) };
                 }
                 4 => {
-                    let ptr = args.get(1).unwrap().as_float().unwrap();
-                    let ptr2 = args.get(2).unwrap().as_float().unwrap();
-                    let ptr3 = args.get(3).unwrap().as_float().unwrap();
-                    let ptr4 = args.get(4).unwrap().as_float().unwrap();
+                    let ptr = args
+                        .get(1)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
+                    let ptr2 = args
+                        .get(2)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
+                    let ptr3 = args
+                        .get(3)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
+                    let ptr4 = args
+                        .get(4)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
                     unsafe {
                         __invokeHostFunc_4_0(
                             func_id,
@@ -471,11 +541,46 @@ fn add_host_functions(this: Ctx<'_>) -> anyhow::Result<()> {
                     };
                 }
                 5 => {
-                    let ptr = args.get(1).unwrap().as_float().unwrap();
-                    let ptr2 = args.get(2).unwrap().as_float().unwrap();
-                    let ptr3 = args.get(3).unwrap().as_float().unwrap();
-                    let ptr4 = args.get(4).unwrap().as_float().unwrap();
-                    let ptr5 = args.get(5).unwrap().as_float().unwrap();
+                    let ptr = args
+                        .get(1)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
+                    let ptr2 = args
+                        .get(2)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
+                    let ptr3 = args
+                        .get(3)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
+                    let ptr4 = args
+                        .get(4)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
+                    let ptr5 = args
+                        .get(5)
+                        .unwrap()
+                        .as_big_int()
+                        .unwrap()
+                        .clone()
+                        .to_i64()
+                        .unwrap();
                     unsafe {
                         __invokeHostFunc_5_0(
                             func_id,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -20,9 +20,12 @@ extern "C" fn init() {
     let mut code = String::new();
     io::stdin().read_to_string(&mut code).unwrap();
 
-    let _ = context.with(|this| {
-        this.eval(code)?;
-        Ok::<_, rquickjs::Error>(Undefined)
+    let _ = context.with(|this| -> Result<rquickjs::Undefined, rquickjs::Error> {
+        match this.eval(code) {
+            Ok(()) => (),
+            Err(e) => return Err(e),
+        }
+        Ok(Undefined)
     });
 
     unsafe {
@@ -103,6 +106,7 @@ fn invoke<'a, T, F: for<'b> Fn(Ctx<'b>, Value<'b>) -> T>(
 #[no_mangle]
 pub extern "C" fn __arg_start() {
     unsafe {
+        extism_pdk::info!("ARG START");
         CALL_ARGS.push(vec![]);
     }
 }
@@ -117,6 +121,7 @@ pub extern "C" fn __arg_i32(arg: i32) {
 #[no_mangle]
 pub extern "C" fn __arg_i64(arg: i64) {
     unsafe {
+        extism_pdk::info!("ARG: {}", arg);
         CALL_ARGS.last_mut().unwrap().push(ArgType::I64(arg));
     }
 }

--- a/examples/bundled/package-lock.json
+++ b/examples/bundled/package-lock.json
@@ -17,7 +17,7 @@
     },
     "../../crates/core/src/prelude": {
       "name": "@extism/js-pdk",
-      "version": "1.0.1",
+      "version": "1.1.1",
       "dev": true,
       "license": "BSD-Clause-3",
       "dependencies": {

--- a/examples/host_funcs/requirements.txt
+++ b/examples/host_funcs/requirements.txt
@@ -1,1 +1,1 @@
-extism==1.0.0rc1
+extism==1.0.2

--- a/examples/react/package-lock.json
+++ b/examples/react/package-lock.json
@@ -21,7 +21,7 @@
     },
     "../../crates/core/src/prelude": {
       "name": "@extism/js-pdk",
-      "version": "1.0.1",
+      "version": "1.1.1",
       "dev": true,
       "license": "BSD-Clause-3",
       "dependencies": {


### PR DESCRIPTION
Closes #104 

This fixes an issue with host function parameter conversion. The solution is using `BigInt` for the extism pointers to avoid truncating the values. 