### PR TITLE
fix: pin ubuntu and update install script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         include:
           - name: linux
-            os: ubuntu-latest
+            os: ubuntu-22.04
           # Re-enable once we can build on Windows again
           # - name: windows
           #   os: windows-latest

--- a/.github/workflows/ci_install.yml
+++ b/.github/workflows/ci_install.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         include:
           - name: linux
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - name: windows
             os: windows-latest
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   compile_core:
     name: Compile Core
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v1
 

--- a/install.sh
+++ b/install.sh
@@ -1,23 +1,29 @@
 #!/bin/bash
 set -eou pipefail
 
-# Get the latest release
-RELEASE_API_URL="https://api.github.com/repos/extism/js-pdk/releases/latest"
-response=$(curl -s "$RELEASE_API_URL")
-if [ -z "$response" ]; then
-    echo "Error: Failed to fetch the latest release from GitHub API."
-    exit 1
+# Check if a specific tag was provided
+if [ $# -eq 1 ]; then
+    LATEST_TAG="$1"
+    echo "Using specified tag: $LATEST_TAG"
+else
+    # Get the latest release
+    RELEASE_API_URL="https://api.github.com/repos/extism/js-pdk/releases/latest"
+    response=$(curl -s "$RELEASE_API_URL")
+    if [ -z "$response" ]; then
+        echo "Error: Failed to fetch the latest release from GitHub API."
+        exit 1
+    fi
+
+    # try to parse tag
+    LATEST_TAG=$(echo "$response" | grep -m 1 '"tag_name":' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
+
+    if [ -z "$LATEST_TAG" ]; then
+        echo "Error: Could not find the latest release tag."
+        exit 1
+    fi
+
+    echo "Installing extism-js latest release with tag: $LATEST_TAG"
 fi
-
-# try to parse tag
-LATEST_TAG=$(echo "$response" | grep -m 1 '"tag_name":' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
-
-if [ -z "$LATEST_TAG" ]; then
-    echo "Error: Could not find the latest release tag."
-    exit 1
-fi
-
-echo "Installing extism-js release with tag: $LATEST_TAG"
 
 OS=''
 case `uname` in
@@ -133,4 +139,3 @@ if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
 fi
 
 echo "Installation complete. Try to run 'extism-js --version' to ensure it was correctly installed."
-


### PR DESCRIPTION
 - update the install script so that we can specify a tag
 - pin the build runners to ubuntu-22.04 to make sure it doesn't need newer glibc versions:

```
❯ extism-js --version
extism-js: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by extism-js)
```

This error is on my machine which is on ubuntu 22.04