### PR TITLE
chore: update version to 1.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.4.1"
+version = "1.5.0"
 edition = "2021"
 authors = ["The Extism Authors"]
 license = "BSD-Clause-3"


### PR DESCRIPTION
Sorry for the noise - going to release 1.5.0 instead. I forgot about https://github.com/extism/js-pdk/pull/125