### PR TITLE
chore: add http headers to HttpResponse interface

### DIFF
--- a/crates/core/src/prelude/src/http.ts
+++ b/crates/core/src/prelude/src/http.ts
@@ -18,6 +18,7 @@ declare global {
   interface HttpResponse {
     body: string;
     status: number;
+    headers: Record<string, string>;
   }
 
   var Http: {

--- a/crates/core/src/prelude/src/http.ts
+++ b/crates/core/src/prelude/src/http.ts
@@ -18,7 +18,10 @@ declare global {
   interface HttpResponse {
     body: string;
     status: number;
-    headers: Record<string, string>;
+    /**
+     * the host needs to enable allow_http_response_headers for this to be present
+     */
+    headers?: Record<string, string>;
   }
 
   var Http: {


### PR DESCRIPTION
follow-up to https://github.com/extism/js-pdk/issues/101 and https://github.com/extism/js-pdk/pull/103.
while https://github.com/extism/js-pdk/pull/103 changes the javascript object, it is not exposed in the typescript types.