### PR TITLE
chore: update rquickjs to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,9 +427,9 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "convert_case"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1040,9 +1040,9 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "js-pdk-cli"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "js-pdk-core"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1997,9 +1997,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a"
+checksum = "c0688f8b0192998cca685adefdfad3483da295fa40a0ec406b4c14ecd729e858"
 dependencies = [
  "rquickjs-core",
  "rquickjs-macro",
@@ -2007,20 +2007,20 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-core"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8bf7840285c321c3ab20e752a9afb95548c75cd7f4632a0627cea3507e310c1"
+checksum = "2fee8c5383f0cfda3b980a80ca4520e726e09b593c59562f579daa51b6c20411"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "relative-path",
  "rquickjs-sys",
 ]
 
 [[package]]
 name = "rquickjs-macro"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7106215ff41a5677b104906a13e1a440b880f4b6362b5dc4f3978c267fad2b80"
+checksum = "04e6cf4b6e695b526cb430a6f445d3ccb9908696b99f1c1f8a1480af38bed5e6"
 dependencies = [
  "convert_case",
  "fnv",
@@ -2035,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-sys"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27344601ef27460e82d6a4e1ecb9e7e99f518122095f3c51296da8e9be2b9d83"
+checksum = "698077537c286a169de8693b216672bcef148bf2e2e112ebf50758c68e9afa09"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "js-pdk-cli"
-version = "1.5.2"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -1399,7 +1399,7 @@ dependencies = [
 
 [[package]]
 name = "js-pdk-core"
-version = "1.5.2"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 authors = ["The Extism Authors"]
 license = "BSD-Clause-3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.5.2"
+version = "1.6.1"
 edition = "2021"
 authors = ["The Extism Authors"]
 license = "BSD-Clause-3"

--- a/crates/cli/src/shims.rs
+++ b/crates/cli/src/shims.rs
@@ -94,8 +94,8 @@ pub fn generate_wasm_shims(
     let mut get_function_arg_type_builder = wagen::Builder::default();
 
     for (func_idx, (_name, _index, params, _results)) in import_items.iter().enumerate() {
-        for arg_idx in 0..params.len() {
-            let type_code = match params[arg_idx] {
+        for (arg_idx, param) in params.iter().enumerate() {
+            let type_code = match param {
                 ValType::I32 => TypeCode::I32,
                 ValType::I64 => TypeCode::I64,
                 ValType::F32 => TypeCode::F32,
@@ -137,7 +137,7 @@ pub fn generate_wasm_shims(
 
     // Create converters for each host function to reinterpret the I64 bit pattern as the expected type
     let mut converter_indices = Vec::new();
-    for (_, (name, _index, params, results)) in import_items.iter().enumerate() {
+    for (name, _index, params, results) in import_items.iter() {
         let import_type = module
             .types()
             .push(|t| t.function(params.clone(), results.clone()));
@@ -208,15 +208,15 @@ pub fn generate_wasm_shims(
 
         // Create the converter function
         let mut shim_params = vec![ValType::I32]; // Function index
-        shim_params.extend(std::iter::repeat(ValType::I64).take(params.len()));
+        shim_params.extend(std::iter::repeat_n(ValType::I64, params.len()));
 
         let conv_func = module.func(
-            &format!("__conv_{}", name),
+            format!("__conv_{}", name),
             shim_params,
             vec![ValType::I64],
             vec![],
         );
-        conv_func.export(&format!("__conv_{}", name));
+        conv_func.export(format!("__conv_{}", name));
         conv_func.body = builder;
 
         converter_indices.push(conv_func.index);

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,7 +12,7 @@ extism-pdk = "1.3"
 once_cell = "1.16"
 anyhow = { workspace = true }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-rquickjs = { version = "0.11", features = ["array-buffer", "bindgen"]}
+rquickjs = { version = "0.12", features = ["array-buffer", "bindgen"]}
 base64 = "0.22.1"
 getrandom = "0.2"
 sha1 = "0.10"

--- a/examples/buffer_npm/.gitignore
+++ b/examples/buffer_npm/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist


### PR DESCRIPTION
Successfully ran `make`, `make test`, and `cargo clippy -- -D warnings`. [rquickjs changelog](https://github.com/DelSkayn/rquickjs/blob/master/CHANGELOG.md#0120---2026-05-26), [quickjs-ng changelog](https://github.com/quickjs-ng/quickjs/releases/tag/v0.12.0)