### PR TITLE
Fix install.sh aborting due to early SIGPIPE

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ else
     fi
 
     # try to parse tag
-    LATEST_TAG=$(echo "$response" | grep -m 1 '"tag_name":' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
+    LATEST_TAG=$(grep -m 1 '"tag_name":' <<< "$response" | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
 
     if [ -z "$LATEST_TAG" ]; then
         echo "Error: Could not find the latest release tag."


### PR DESCRIPTION
grep -m 1 can cause early exit to echo with SIGPIPE upon the first match. With `set -e`, this causes the entire script to fail.

Feed "$response" to grep directly.